### PR TITLE
[Feature] Add spell name localisation

### DIFF
--- a/Thaliz/Libs/AceLocale-3.0/AceLocale-3.0.lua
+++ b/Thaliz/Libs/AceLocale-3.0/AceLocale-3.0.lua
@@ -1,0 +1,137 @@
+--- **AceLocale-3.0** manages localization in addons, allowing for multiple locale to be registered with fallback to the base locale for untranslated strings.
+-- @class file
+-- @name AceLocale-3.0
+-- @release $Id: AceLocale-3.0.lua 1035 2011-07-09 03:20:13Z kaelten $
+local MAJOR,MINOR = "AceLocale-3.0", 6
+
+local AceLocale, oldminor = LibStub:NewLibrary(MAJOR, MINOR)
+
+if not AceLocale then return end -- no upgrade needed
+
+-- Lua APIs
+local assert, tostring, error = assert, tostring, error
+local getmetatable, setmetatable, rawset, rawget = getmetatable, setmetatable, rawset, rawget
+
+-- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
+-- List them here for Mikk's FindGlobals script
+-- GLOBALS: GAME_LOCALE, geterrorhandler
+
+local gameLocale = GetLocale()
+if gameLocale == "enGB" then
+	gameLocale = "enUS"
+end
+
+AceLocale.apps = AceLocale.apps or {}          -- array of ["AppName"]=localetableref
+AceLocale.appnames = AceLocale.appnames or {}  -- array of [localetableref]="AppName"
+
+-- This metatable is used on all tables returned from GetLocale
+local readmeta = {
+	__index = function(self, key) -- requesting totally unknown entries: fire off a nonbreaking error and return key
+		rawset(self, key, key)      -- only need to see the warning once, really
+		geterrorhandler()(MAJOR..": "..tostring(AceLocale.appnames[self])..": Missing entry for '"..tostring(key).."'")
+		return key
+	end
+}
+
+-- This metatable is used on all tables returned from GetLocale if the silent flag is true, it does not issue a warning on unknown keys
+local readmetasilent = {
+	__index = function(self, key) -- requesting totally unknown entries: return key
+		rawset(self, key, key)      -- only need to invoke this function once
+		return key
+	end
+}
+
+-- Remember the locale table being registered right now (it gets set by :NewLocale())
+-- NOTE: Do never try to register 2 locale tables at once and mix their definition.
+local registering
+
+-- local assert false function
+local assertfalse = function() assert(false) end
+
+-- This metatable proxy is used when registering nondefault locales
+local writeproxy = setmetatable({}, {
+	__newindex = function(self, key, value)
+		rawset(registering, key, value == true and key or value) -- assigning values: replace 'true' with key string
+	end,
+	__index = assertfalse
+})
+
+-- This metatable proxy is used when registering the default locale.
+-- It refuses to overwrite existing values
+-- Reason 1: Allows loading locales in any order
+-- Reason 2: If 2 modules have the same string, but only the first one to be
+--           loaded has a translation for the current locale, the translation
+--           doesn't get overwritten.
+--
+local writedefaultproxy = setmetatable({}, {
+	__newindex = function(self, key, value)
+		if not rawget(registering, key) then
+			rawset(registering, key, value == true and key or value)
+		end
+	end,
+	__index = assertfalse
+})
+
+--- Register a new locale (or extend an existing one) for the specified application.
+-- :NewLocale will return a table you can fill your locale into, or nil if the locale isn't needed for the players
+-- game locale.
+-- @paramsig application, locale[, isDefault[, silent]]
+-- @param application Unique name of addon / module
+-- @param locale Name of the locale to register, e.g. "enUS", "deDE", etc.
+-- @param isDefault If this is the default locale being registered (your addon is written in this language, generally enUS)
+-- @param silent If true, the locale will not issue warnings for missing keys. Must be set on the first locale registered. If set to "raw", nils will be returned for unknown keys (no metatable used).
+-- @usage
+-- -- enUS.lua
+-- local L = LibStub("AceLocale-3.0"):NewLocale("TestLocale", "enUS", true)
+-- L["string1"] = true
+--
+-- -- deDE.lua
+-- local L = LibStub("AceLocale-3.0"):NewLocale("TestLocale", "deDE")
+-- if not L then return end
+-- L["string1"] = "Zeichenkette1"
+-- @return Locale Table to add localizations to, or nil if the current locale is not required.
+function AceLocale:NewLocale(application, locale, isDefault, silent)
+
+	-- GAME_LOCALE allows translators to test translations of addons without having that wow client installed
+	local gameLocale = GAME_LOCALE or gameLocale
+
+	local app = AceLocale.apps[application]
+
+	if silent and app and getmetatable(app) ~= readmetasilent then
+		geterrorhandler()("Usage: NewLocale(application, locale[, isDefault[, silent]]): 'silent' must be specified for the first locale registered")
+	end
+
+	if not app then
+		if silent=="raw" then
+			app = {}
+		else
+			app = setmetatable({}, silent and readmetasilent or readmeta)
+		end
+		AceLocale.apps[application] = app
+		AceLocale.appnames[app] = application
+	end
+
+	if locale ~= gameLocale and not isDefault then
+		return -- nop, we don't need these translations
+	end
+
+	registering = app -- remember globally for writeproxy and writedefaultproxy
+
+	if isDefault then
+		return writedefaultproxy
+	end
+
+	return writeproxy
+end
+
+--- Returns localizations for the current locale (or default locale if translations are missing).
+-- Errors if nothing is registered (spank developer, not just a missing translation)
+-- @param application Unique name of addon / module
+-- @param silent If true, the locale is optional, silently return nil if it's not found (defaults to false, optional)
+-- @return The locale table for the current language.
+function AceLocale:GetLocale(application, silent)
+	if not silent and not AceLocale.apps[application] then
+		error("Usage: GetLocale(application[, silent]): 'application' - No locales registered for '"..tostring(application).."'", 2)
+	end
+	return AceLocale.apps[application]
+end

--- a/Thaliz/Libs/AceLocale-3.0/AceLocale-3.0.xml
+++ b/Thaliz/Libs/AceLocale-3.0/AceLocale-3.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+	<Script file="AceLocale-3.0.lua"/>
+</Ui>

--- a/Thaliz/Libs/LibStub/LibStub.lua
+++ b/Thaliz/Libs/LibStub/LibStub.lua
@@ -1,0 +1,30 @@
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/wiki/LibStub for more info
+-- LibStub is hereby placed in the Public Domain Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+	
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(strmatch(minor, "%d+")), "Minor version must either be a number or contain a number.")
+		
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+	
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+	
+	function LibStub:IterateLibraries() return pairs(self.libs) end
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end

--- a/Thaliz/Locales/Locales.xml
+++ b/Thaliz/Locales/Locales.xml
@@ -1,0 +1,11 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+    <Script file="deDE.lua"/>
+    <Script file="enUS.lua"/>
+    <Script file="esES.lua"/>
+    <Script file="frFR.lua"/>
+    <Script file="koKR.lua"/>
+    <Script file="ptBR.lua"/>
+    <Script file="ruRU.lua"/>
+    <Script file="zhCN.lua"/>
+</Ui>

--- a/Thaliz/Locales/deDE.lua
+++ b/Thaliz/Locales/deDE.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "deDE")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "Geist der Ahnen"
+L["Rebirth"] = "Wiedergeburt"
+L["Redemption"] = "Erlösung"
+L["Resurrection"] = "Auferstehung"

--- a/Thaliz/Locales/enUS.lua
+++ b/Thaliz/Locales/enUS.lua
@@ -1,0 +1,7 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "enUS", true)
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "Ancestral Spirit"
+L["Rebirth"] = "Rebirth"
+L["Redemption"] = "Redemption"
+L["Resurrection"] = "Resurrection"

--- a/Thaliz/Locales/esES.lua
+++ b/Thaliz/Locales/esES.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "esES")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "Espíritu ancestral"
+L["Rebirth"] = "Renacer"
+L["Redemption"] = "Redención"
+L["Resurrection"] = "Resurrección"

--- a/Thaliz/Locales/frFR.lua
+++ b/Thaliz/Locales/frFR.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "frFR")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "Esprit Ancestral"
+L["Rebirth"] = "Renaissance"
+L["Redemption"] = "Rédemption"
+L["Resurrection"] = "Résurrection"

--- a/Thaliz/Locales/koKR.lua
+++ b/Thaliz/Locales/koKR.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "koKR")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "고대의 영혼"
+L["Rebirth"] = "환생"
+L["Redemption"] = "구원"
+L["Resurrection"] = "부활"

--- a/Thaliz/Locales/ptBR.lua
+++ b/Thaliz/Locales/ptBR.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "ptBR")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "Espírito Ancestral"
+L["Rebirth"] = "Renascimento"
+L["Redemption"] = "Redenção"
+L["Resurrection"] = "Ressurreição"

--- a/Thaliz/Locales/ruRU.lua
+++ b/Thaliz/Locales/ruRU.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "ruRU")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "Дух предков"
+L["Rebirth"] = "Возрождение"
+L["Redemption"] = "Искупление"
+L["Resurrection"] = "Воскрешение"

--- a/Thaliz/Locales/zhCN.lua
+++ b/Thaliz/Locales/zhCN.lua
@@ -1,0 +1,8 @@
+local L = LibStub("AceLocale-3.0"):NewLocale("Thaliz", "zhCN")
+if not L then return end
+
+-- Resurrection spell name
+L["Ancestral Spirit"] = "先祖之魂"
+L["Rebirth"] = "复生"
+L["Redemption"] = "救赎"
+L["Resurrection"] = "复活术"

--- a/Thaliz/Thaliz.lua
+++ b/Thaliz/Thaliz.lua
@@ -11,6 +11,7 @@ https://github.com/Sentilix/thaliz-classic
 Please see the ReadMe.txt for addon details.
 ]]
 
+local L = LibStub("AceLocale-3.0"):GetLocale("Thaliz", true)
 
 local PARTY_CHANNEL							= "PARTY"
 local RAID_CHANNEL							= "RAID"
@@ -42,15 +43,15 @@ local EMOTE_GROUP_RACE						= "Race";
 --	List of valid class names with priority and resurrection spell name (if any)
 --	classname, priority, ress spellname
 local classInfo = {
-	{ "Druid",   40, "Rebirth"			},
-	{ "Hunter",  30, nil				},
-	{ "Mage",    40, nil				},
-	{ "Paladin", 50, "Redemption"		},
-	{ "Priest",  50, "Resurrection"		},
-	{ "Rogue",   10, nil				},
-	{ "Shaman",  50, "Ancestral Spirit"	},
-	{ "Warlock", 30, nil				},
-	{ "Warrior", 20, nil				}
+	{ "Druid",   40, L["Rebirth"]			},
+	{ "Hunter",  30, nil					},
+	{ "Mage",    40, nil					},
+	{ "Paladin", 50, L["Redemption"]		},
+	{ "Priest",  50, L["Resurrection"]		},
+	{ "Rogue",   10, nil					},
+	{ "Shaman",  50, L["Ancestral Spirit"]	},
+	{ "Warlock", 30, nil					},
+	{ "Warrior", 20, nil					}
 };
 
 

--- a/Thaliz/Thaliz.toc
+++ b/Thaliz/Thaliz.toc
@@ -4,4 +4,10 @@
 ## Author: Mimma @ <EU-Pyrewood Village>
 ## Interface: 11305
 ## SavedVariables: Thaliz_Options
+	
+Libs\LibStub\LibStub.lua
+Libs\AceLocale-3.0\AceLocale-3.0.xml
+
+Locales\Locales.xml
+
 Thaliz.xml


### PR DESCRIPTION
This PR add the spell name localization in 7 new locales using Ace3 library.

It allows the addon to works with these 7 non-english clients.

I took the translations from the Wowhead website.

Closes #2 

Note: using external translations instead of spellID does not imply a much more refactoring of the .lua file, and introduces a way to translate other texts within the addon, like messages, commands or configuration window.