### PR TITLE
Add type check to prevent accidental indexing of numbers

### DIFF
--- a/Thaliz/Thaliz.lua
+++ b/Thaliz/Thaliz.lua
@@ -975,12 +975,14 @@ function Thaliz_ParseProfileNames()
 
 		if type(realmInfo) == "table" then
 			for playerName, playerInfo in next, realmInfo do
-				local messages = playerInfo["ResurrectionMessages"];
-				if messages and type(messages) == "table" and table.getn(messages) > 0 then	
-					local playerRealm = playerName .."-".. string.gsub(realmName, " ", "");
+				if type(playerInfo) == "table" then
+					local messages = playerInfo["ResurrectionMessages"];
+					if messages and type(messages) == "table" and table.getn(messages) > 0 then	
+						local playerRealm = playerName .."-".. string.gsub(realmName, " ", "");
 
-					tinsert(Thaliz_ProfileTable, { ["realm"] = realmName, ["name"] = playerName, ["count"] = table.getn(messages), ["fullname"] = playerRealm });
-				end;
+						tinsert(Thaliz_ProfileTable, { ["realm"] = realmName, ["name"] = playerName, ["count"] = table.getn(messages), ["fullname"] = playerRealm });
+					end;
+				end
 			end;
 		end;
 	end;


### PR DESCRIPTION
Everytime I login into the game, I instantly get an error because thaliz is trying to index a number instead of a table when parsing the new profile based configs added in the 3.1.0 version. I added a small type check to the for loop to prevent those lua errors from showing up. Maybe this happens only to users with an older Thaliz_Config structure, but I didn't have the time to look at it in detail.

When I print out running `/run for realmName, realmInfo in next, Thaliz_Options do if type(realmInfo) == "table" then for playerName, playerInfo in next, realmInfo do print(realmName, playerName, playerInfo) end end end` I get these results:

![image](https://user-images.githubusercontent.com/1218727/175816088-c1caed63-61f8-49ee-b802-c8ff7d6a9d06.png)
(The red bars are other characters of mine)

It seems that the playername and the profile settings are somehow mixed up.